### PR TITLE
Add `arSupported` check when clicking viewARButton

### DIFF
--- a/index.html
+++ b/index.html
@@ -337,6 +337,8 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
       }
 
       viewARButton.addEventListener('click', () => {
+        if (!arSupported) return;
+        
         appState.screen = SCREEN.Select;
         appState.viewMode = VIEW_MODE.AR;
         updateAppState();


### PR DESCRIPTION
I just noticed that if you are on desktop without XR support (Chrome on Mac for example) you are able to click the AR button even so it seems to be disabled. It lets me select the dinosaur and the funny result is that it looks really small on 3D.
I just added a check to prevent it to jump to the selection menu if there is no AR support
![ezgif com-resize](https://user-images.githubusercontent.com/782511/79606042-43220c80-80f1-11ea-8323-4a99aa104811.gif)



 