### PR TITLE
Fix issue with teleport target rotation and snap turning (#4)

### DIFF
--- a/js/xr-teleport.js
+++ b/js/xr-teleport.js
@@ -538,8 +538,12 @@ export class XRTeleportGuide extends THREE.Group {
     // Set guide velocity to the direction of the controller, at 1m/s
     const v = controller.getWorldDirection(this.guideCurve.velocity);
 
-    // Rotate the target texture to always be oriented the same way as the guide beam.
-    this.targetMesh.rotation.z = Math.atan2(v.x, v.z);
+    // Rotate the target texture to always be oriented the same way as the guide beam,
+    // accounting for snap turning.
+    const targetAngle = Math.atan2(v.x, v.z);
+    const refQuaternion = this.getWorldQuaternion(new THREE.Quaternion());
+    const refRotation = new THREE.Euler(0, 0, 0, 'YXZ').setFromQuaternion(refQuaternion); // Y-first to allow 2π range
+    this.targetMesh.rotation.z = targetAngle - refRotation.y;
 
     // Scale the initial velocity
     v.multiplyScalar(this.options.teleportVelocity);


### PR DESCRIPTION
This is an attempt to address issue #4 by adjusting world rotation to local rotation by subtracting rotation due to snap turning. I don't know if there's a simpler way to address this, but it seems to fix the issue in my testing.